### PR TITLE
Cleaned up definition of emulsions, allowing to define empty emulsions

### DIFF
--- a/droplets/droplets.py
+++ b/droplets/droplets.py
@@ -1,6 +1,9 @@
 """
 Classes representing (perturbed) droplets in various dimensions
 
+The classes differ in what features of a droplet they track. In the simplest case, only
+the position and radius of a spherical droplet are stored. Other classes additionally
+keep track of the interfacial width or shape perturbations (of various degrees).
 
 .. autosummary::
    :nosignatures:
@@ -240,7 +243,7 @@ class DropletBase:
         return np.full(num, -np.inf), np.full(num, np.inf)
 
 
-class SphericalDroplet(DropletBase):  # lgtm [py/missing-equals]
+class SphericalDroplet(DropletBase):
     """Represents a single, spherical droplet"""
 
     __slots__ = ["data"]
@@ -1181,13 +1184,14 @@ class PerturbedDroplet3D(PerturbedDropletBase):
         raise NotImplementedError("Plotting PerturbedDroplet3D is not implemented")
 
 
-def droplet_from_data(droplet_class: str, data) -> DropletBase:
+def droplet_from_data(droplet_class: str, data: np.ndarray) -> DropletBase:
     """create a droplet instance of the given class using some data
 
     Args:
-        droplet_class (str): The name of the class that is used to create the
-            droplet instance
-        data (numpy.ndarray): A numpy array that defines the droplet properties
+        droplet_class (str):
+            The name of the class that is used to create the droplet instance
+        data (:class:`~numpy.ndarray`):
+            A numpy array that defines the droplet properties
     """
     cls = DropletBase._subclasses[droplet_class]
     return cls(**{key: data[key] for key in data.dtype.names})  # type: ignore

--- a/droplets/emulsions.py
+++ b/droplets/emulsions.py
@@ -494,23 +494,17 @@ class Emulsion(list):
 
         return dists
 
-    def get_neighbor_distances(
-        self, subtract_radius: bool = False, grid: Optional[GridBase] = None
-    ) -> np.ndarray:
+    def get_neighbor_distances(self, subtract_radius: bool = False) -> np.ndarray:
         """calculates the distance of each droplet to its nearest neighbor
 
         Warning:
-            Nearest neighbors are defined by comparing the distances between the centers
-            of the droplets, not their surfaces.
+            This function does not take periodic boundary conditions into account.
 
         Args:
             subtract_radius (bool):
                 Determines whether to subtract the radius from the distance, i.e.,
                 whether to return the distance between the surfaces instead of the
                 positions
-            grid (:class:`~pde.grids.base.GridBase`):
-                The grid on which the droplets are defined, which is necessary if
-                periodic boundary conditions should be respected for measuring distances
 
         Returns:
             :class:`~numpy.ndarray`: a vector with a distance for each droplet
@@ -530,8 +524,7 @@ class Emulsion(list):
         assert self.data is not None
         positions = self.data["position"]
 
-        # TODO: respect periodic boundary conditions using `boxsize` argument
-
+        # we could support periodic boundary conditions using `freud.locality.AABBQuery`
         tree = KDTree(positions)
         dist, index = tree.query(positions, 2)
 

--- a/droplets/trackers.py
+++ b/droplets/trackers.py
@@ -179,26 +179,6 @@ class DropletTracker(TrackerBase):
         self.refine = refine
         self.perturbation_modes = perturbation_modes
 
-    def initialize(self, field: FieldBase, info: Optional[InfoDict] = None) -> float:
-        """
-        Args:
-            field (:class:`~pde.fields.base.FieldBase`):
-                An example of the data that will be analyzed by the tracker
-            info (dict):
-                Extra information from the simulation
-
-        Returns:
-            float: The first time the tracker needs to handle data
-        """
-        if self.data.grid is None:
-            self.data.grid = field.grid
-        elif not self.data.grid.compatible_with(field.grid):
-            raise RuntimeError(
-                "Grid of the Emulsion is incompatible with the grid of current state"
-            )
-
-        return super().initialize(field, info)
-
     def handle(self, field: FieldBase, t: float) -> None:
         """handle data supplied to this tracker
 

--- a/tests/test_image_analysis.py
+++ b/tests/test_image_analysis.py
@@ -284,16 +284,15 @@ def test_get_length_scale_edge():
 
 def test_emulsion_processing():
     """test identifying emulsions in phase fields"""
-    grid = UnitGrid([32, 32], periodic=True)
-
     e1 = Emulsion(
         [
             DiffuseDroplet(position=[5, 6], radius=9, interface_width=1),
             DiffuseDroplet(position=[20, 19], radius=8, interface_width=1),
-        ],
-        grid=grid,
+        ]
     )
-    field = e1.get_phasefield()
+
+    grid = UnitGrid([32, 32], periodic=True)
+    field = e1.get_phasefield(grid)
 
     e2 = image_analysis.locate_droplets(field, refine=True)
 


### PR DESCRIPTION
* Removed `grid` attribute from `Emulsion` and similar classes
* Instead, grid instances can now be specified when distances are important, which separates concerns better
* Added explicit `dtype` attribute to emulsions to clearly specify type of droplets in empty emulsions. This can often be ignored, though.